### PR TITLE
Fixed crash on start

### DIFF
--- a/lib/node-i3.js
+++ b/lib/node-i3.js
@@ -71,7 +71,7 @@ function i3(path) {
     }
   });
 };
-sys.inherits(i3, process.EventEmitter);
+sys.inherits(i3, EventEmitter);
 exports.i3 = i3;
 
 /* constants */


### PR DESCRIPTION
```
App threw an error during load
TypeError: The super constructor to "inherits" must not be null or undefined
    at Object.exports.inherits (util.js:962:11)
    at Object.<anonymous> (/home/joseph/random/electron-quick-start/node_modules/node-i3/lib/node-i3.js:76:5)
    at Object.<anonymous> (/home/joseph/random/electron-quick-start/node_modules/node-i3/lib/node-i3.js:180:3)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
```

It seems that the change was made to import `EventEmitter` from the `events` module instead of `process`, but it was never actually used.